### PR TITLE
Adjustments for building with clay-0.13

### DIFF
--- a/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
+++ b/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
@@ -43,7 +43,7 @@ class ToStyle a where
 
 -- |Convert a Clay Property to Threepnny style.
 instance ToStyle Rule where
-  toStyle (Property k v) =
+  toStyle (Property [] k v) =
     [(unpack $ unPlain $ unKeys k, unpack $ unPlain $ unValue v)]
 
 -- |Properties for a parent.

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.12
+resolver: lts-16.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/threepenny-gui-flexbox.cabal
+++ b/threepenny-gui-flexbox.cabal
@@ -16,7 +16,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Graphics.UI.Threepenny.Ext.Flexbox
   build-depends:       base >= 4.7 && < 5
-                     , clay
+                     , clay >= 0.13
                      , text
                      , threepenny-gui
   default-language:    Haskell2010


### PR DESCRIPTION
[_clay_'s `Property` constructor](https://hackage.haskell.org/package/clay-0.13.2/docs/src/Clay.Stylesheet.html#Rule) has gained an extra field in version 0.13. For that reason, _threepenny-gui-flexbox_ currently won't build with _clay_-0.13.* or _base_ >= 4.12 (because of an upper bound which was relaxed in _clay_-0.13.1). This pull request rectifies that, while adjusting the _clay_ lower bound and the resolver accordingly.