### PR TITLE
Combine properties monoidally

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,17 @@ If you want `ChildProps` with `flex-grow: 1;` you can just do:
 flexGrow 1
 ```
 
-You can define multiple properties using record syntax:
+You can define multiple properties using `(<>)`:
 
 ``` Haskell
-order 1 { cflexGrow = 1, cFlexShrink = 2 }
+order 1 <> flexGrow 1 <> flexShrink 2
 ```
-
-Note that in the examples above we used `flexGrow` and `order` to return
-`ChildProps` with given values set but also with default values set for all
-other Flexbox properties, unless record syntax is used to override a property.
 
 Some properties like `flexGrow` simply take an `Int` but others take a value
 from the `Clay` library. Here's an example for `ParentProps`:
 
 ``` Haskell
-display Clay.Display.inlineFlex { pFlexWrap = Clay.Flexbox.nowrap }
+display Clay.Display.inlineFlex <> flexWrap Clay.Flexbox.nowrap
 ```
 
 If you just want `ParentProps` or `ChildProps` with default values:
@@ -64,11 +60,29 @@ application operator `#`:
 UI.div # set UI.text "foo" # setFlex (flexGrow 1)
 ```
 
+Note that `setFlex` will set any properties you don't specify explictly to the
+default values from `parentProps` or `childProps`. If that is undesirable (for
+instance, in case you have already used `setFlex` elsewhere to set several
+properties and only want to change a few of them), you can instead use
+`modifyFlex`, which leaves unspecified properties unchanged:
+
+``` Haskell
+myRow = UI.div # setFlex (
+    flexDirection Clay.Flexbox.row
+    <> flexWrap Clay.Flexbox.wrap
+    <> justifyContent Clay.Flexbox.spaceBetween
+    <> alignItems Clay.Common.baseline
+  )
+
+-- Elsewhere:
+myRow # modifyFlex (alignItems Clay.Common.center)
+```
+
 You can also convert `ParentProps` or `ChildProps` to a `[(String, String)]`
 which
 is
 [how Threepenny expects CSS](http://hackage.haskell.org/package/threepenny-gui/docs/src/Graphics-UI-Threepenny-Core.html#style).
-This can be done using `toStyle` which is defined in the typeclass `ToStyle`:
+This can be done using `toStyle`:
 
 ``` Haskell
 UI.div # set UI.style (toStyle $ order 1)
@@ -78,8 +92,8 @@ UI.div # set UI.style (toStyle $ order 1)
 
 We provide a utility function `flex` (and a few variants thereof) which takes
 both parent and child elements and their respective `ParentProps` and
-`ChildProps`, applies the properties to the respective elements and then returns
-the parent element with children attached.
+`ChildProps`, applies the properties through `setFlex` to the respective
+elements and then returns the parent element with children attached.
 
 Here is a full example, which produces the above image of three orange text
 boxes in ratio 1:2:1. First done without `flex_p` and then with `flex_p`.

--- a/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
+++ b/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
@@ -16,7 +16,7 @@ module Graphics.UI.Threepenny.Ext.Flexbox (
   order, flexGrow, flexShrink, flexBasis, alignSelf,
 
   -- * Core Functions
-  ToStyle (..), setFlex,
+  ToStyle (..), FlexProps(..), setFlex, modifyFlex,
 
   -- * Useful Abstractions
   flex, flex_p, flex_c, flex_pc
@@ -34,12 +34,20 @@ import           Clay.Property               (unKeys, unPlain, unValue)
 import           Clay.Size                   (LengthUnit, Size)
 import           Clay.Stylesheet             (Rule (Property), runS)
 import           Data.Text                   (unpack)
+import           Data.Monoid                 (Last(..))
+import           Control.Monad               ((<=<))
+import           Data.Maybe                  (mapMaybe)
 import qualified Graphics.UI.Threepenny      as UI
 import           Graphics.UI.Threepenny.Core hiding (column, row)
 
 -- |Convert to Threepenny style.
 class ToStyle a where
   toStyle :: a -> [(String, String)]
+
+-- | A class for bundles of Flexbox properties suitable for application
+--   to 'Elements'.
+class (ToStyle a, Semigroup a) => FlexProps a where
+  defaultFlexProps :: a
 
 -- |Convert a Clay Property to Threepnny style.
 instance ToStyle Rule where
@@ -48,81 +56,131 @@ instance ToStyle Rule where
 
 -- |Properties for a parent.
 data ParentProps = ParentProps {
-    pDisplay        :: Display
-  , pFlexDirection  :: FlexDirection
-  , pFlexWrap       :: FlexWrap
-  , pJustifyContent :: JustifyContentValue
-  , pAlignItems     :: AlignItemsValue
-  , pAlignContent   :: AlignContentValue
+    pDisplay        :: Last Display
+  , pFlexDirection  :: Last FlexDirection
+  , pFlexWrap       :: Last FlexWrap
+  , pJustifyContent :: Last JustifyContentValue
+  , pAlignItems     :: Last AlignItemsValue
+  , pAlignContent   :: Last AlignContentValue
 }
+
+instance Semigroup ParentProps where
+  p1 <> p2 = ParentProps {
+      pDisplay        = pDisplay p1        <> pDisplay p2
+    , pFlexDirection  = pFlexDirection p1  <> pFlexDirection p2
+    , pFlexWrap       = pFlexWrap p1       <> pFlexWrap p2
+    , pJustifyContent = pJustifyContent p1 <> pJustifyContent p2
+    , pAlignItems     = pAlignItems p1     <> pAlignItems p2
+    , pAlignContent   = pAlignContent p1   <> pAlignContent p2
+  }
+
+instance Monoid ParentProps where
+  mempty = ParentProps {
+      pDisplay        = mempty
+    , pFlexDirection  = mempty
+    , pFlexWrap       = mempty
+    , pJustifyContent = mempty
+    , pAlignItems     = mempty
+    , pAlignContent   = mempty
+  }
 
 -- |Convert parent properties to Threepenny style.
 instance ToStyle ParentProps where
-  toStyle p = concatMap toStyle $ concatMap runS [
-        CD.display        $ pDisplay        p
-      , CF.flexDirection  $ pFlexDirection  p
-      , CF.flexWrap       $ pFlexWrap       p
-      , CF.justifyContent $ pJustifyContent p
-      , CF.alignItems     $ pAlignItems     p
-      , CF.alignContent   $ pAlignContent   p
+  toStyle p = concatMap (toStyle <=< runS) $ mapMaybe getLast $ [
+        CD.display        <$> pDisplay        p
+      , CF.flexDirection  <$> pFlexDirection  p
+      , CF.flexWrap       <$> pFlexWrap       p
+      , CF.justifyContent <$> pJustifyContent p
+      , CF.alignItems     <$> pAlignItems     p
+      , CF.alignContent   <$> pAlignContent   p
     ]
 
 -- |Default properties for a parent.
 parentProps :: ParentProps
 parentProps = ParentProps {
-    pDisplay        = CD.flex
-  , pFlexDirection  = CF.row
-  , pFlexWrap       = CF.nowrap
-  , pJustifyContent = CF.flexStart
-  , pAlignItems     = CF.stretch
-  , pAlignContent   = CF.stretch
+    pDisplay        = pure CD.flex
+  , pFlexDirection  = pure CF.row
+  , pFlexWrap       = pure CF.nowrap
+  , pJustifyContent = pure CF.flexStart
+  , pAlignItems     = pure CF.stretch
+  , pAlignContent   = pure CF.stretch
 }
 
-display        x = parentProps { pDisplay        = x }
-flexDirection  x = parentProps { pFlexDirection  = x }
-flexWrap       x = parentProps { pFlexWrap       = x }
-justifyContent x = parentProps { pJustifyContent = x }
-alignItems     x = parentProps { pAlignItems     = x }
-aligContent    x = parentProps { pAlignContent   = x }
+instance FlexProps ParentProps where
+  defaultFlexProps = parentProps
+
+display        x = mempty { pDisplay        = pure x }
+flexDirection  x = mempty { pFlexDirection  = pure x }
+flexWrap       x = mempty { pFlexWrap       = pure x }
+justifyContent x = mempty { pJustifyContent = pure x }
+alignItems     x = mempty { pAlignItems     = pure x }
+aligContent    x = mempty { pAlignContent   = pure x }
 
 -- |Properties for a child.
 data ChildProps = ChildProps {
-    cOrder      :: Int
-  , cFlexGrow   :: Int
-  , cFlexShrink :: Int
-  , cFlexBasis  :: Size LengthUnit
-  , cAlignSelf  :: AlignSelfValue
+    cOrder      :: Last Int
+  , cFlexGrow   :: Last Int
+  , cFlexShrink :: Last Int
+  , cFlexBasis  :: Last (Size LengthUnit)
+  , cAlignSelf  :: Last AlignSelfValue
 }
+
+instance Semigroup ChildProps where
+  c1 <> c2 = ChildProps {
+      cOrder      = cOrder c1      <> cOrder c2
+    , cFlexGrow   = cFlexGrow c1   <> cFlexGrow c2
+    , cFlexShrink = cFlexShrink c1 <> cFlexShrink c2
+    , cFlexBasis  = cFlexBasis c1  <> cFlexBasis c2
+    , cAlignSelf  = cAlignSelf c1  <> cAlignSelf c2
+  }
+
+instance Monoid ChildProps where
+  mempty = ChildProps {
+      cOrder      = mempty
+    , cFlexGrow   = mempty
+    , cFlexShrink = mempty
+    , cFlexBasis  = mempty
+    , cAlignSelf  = mempty
+  }
 
 -- |Convert child properties to Threepenny style.
 instance ToStyle ChildProps where
-  toStyle c = concatMap toStyle $ concatMap runS [
-        CF.order      $ cOrder      c
-      , CF.flexGrow   $ cFlexGrow   c
-      , CF.flexShrink $ cFlexShrink c
-      , CF.flexBasis  $ cFlexBasis  c
-      , CF.alignSelf  $ cAlignSelf  c
+  toStyle c = concatMap (toStyle <=< runS) $ mapMaybe getLast $ [
+        CF.order      <$> cOrder      c
+      , CF.flexGrow   <$> cFlexGrow   c
+      , CF.flexShrink <$> cFlexShrink c
+      , CF.flexBasis  <$> cFlexBasis  c
+      , CF.alignSelf  <$> cAlignSelf  c
     ]
 
 -- |Default properties for a child.
 childProps :: ChildProps
 childProps = ChildProps {
-    cOrder      = 1
-  , cFlexGrow   = 0
-  , cFlexShrink = 1
-  , cFlexBasis  = CC.auto
-  , cAlignSelf  = CC.auto
+    cOrder      = pure 1
+  , cFlexGrow   = pure 0
+  , cFlexShrink = pure 1
+  , cFlexBasis  = pure CC.auto
+  , cAlignSelf  = pure CC.auto
 }
 
-order      x = childProps { cOrder      = x }
-flexGrow   x = childProps { cFlexGrow   = x }
-flexShrink x = childProps { cFlexShrink = x }
-flexBasis  x = childProps { cFlexBasis  = x }
-alignSelf  x = childProps { cAlignSelf  = x }
+instance FlexProps ChildProps where
+  defaultFlexProps = childProps
 
--- |Set Flexbox properties on an element.
-setFlex :: ToStyle a => a -> UI Element -> UI Element
-setFlex props el = el # set UI.style (toStyle props)
+order      x = mempty { cOrder      = pure x }
+flexGrow   x = mempty { cFlexGrow   = pure x }
+flexShrink x = mempty { cFlexShrink = pure x }
+flexBasis  x = mempty { cFlexBasis  = pure x }
+alignSelf  x = mempty { cAlignSelf  = pure x }
+
+-- | Set Flexbox properties on an element. Unspecified properties are
+--   set to the corresponding 'defaultFlexProps' field values.
+setFlex :: FlexProps a => a -> UI Element -> UI Element
+setFlex props = modifyFlex (defaultFlexProps <> props)
+
+-- | Modify Flexbox properties on an element. Unspecified properties
+--   are left unchanged.
+modifyFlex :: FlexProps a => a -> UI Element -> UI Element
+modifyFlex props el = el # set UI.style (toStyle props)
 
 -- |Attach elements to a parent element, applying given Flexbox properties.
 flex ::

--- a/threepenny-gui-flexbox.cabal
+++ b/threepenny-gui-flexbox.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Graphics.UI.Threepenny.Ext.Flexbox
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , clay >= 0.13
                      , text
                      , threepenny-gui


### PR DESCRIPTION
This patch modifies the `ParentProps` and `ChildProps` types in order to give them a `Monoid` instance which combines properties using `Last`. Two benefits of this change are:

- It becomes possible to set only some of the properties without having the other ones reset to the defaults. A `modifyFlex` combinator was added for that purpose.

- `Monoid` provides more comfortable syntax for changing multiple properties. The example in the readme, for instance, goes from:

        order 1 { cflexGrow = 1, cFlexShrink = 2 }

  To:

        order 1 <> flexGrow 1 <> flexShrink 2

In order to allow `setFlex` and `modifyFlex` to use the same types while retaining the original behaviour of `setFlex` when used with the smart constructors, `setFlex` is now defined as:

    setFlex props = modifyFlex (defaultFlexProps <> props) 

With `defaultFlexProps` being `parentProps` for parent properties and `childProps` for child ones. (A minor consequence of this change is that it is no longer possible to pass a Clay `Rule` directly to `setFlex`. If anyone ever wants that, though, it is just a question of using `modifyFlex` instead of `setFlex`.)

The only significant breaking change involved is the change in the types of the record fields. It is expected, though, that in the vast majority of cases fixing client code will only require replacing record updates with uses of `(<>)` and the smart constructors, as demonstrated above. `setFlex` and the combinators built upon it behave just like before.

I have tried the patched library with both the demo `threepenny-flexbox-exe` app and my own Threepenny-powered project (see [here](https://github.com/duplode/stunts-cartography/blob/484db68e5517deea018795dcfbb75928298c9fbf/src/Util/Threepenny/Flexbox.hs) and [here](https://github.com/duplode/stunts-cartography/blob/484db68e5517deea018795dcfbb75928298c9fbf/src/Viewer.hs#L317) for the relevant snippets). There were no changes in the output.

(By the way, thanks for writing this library; it has made setting up the layout in my project quite a bit more pleasant!)