### PR TITLE
Tweaks for better matching the CSS spec

### DIFF
--- a/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
+++ b/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
@@ -7,7 +7,7 @@ module Graphics.UI.Threepenny.Ext.Flexbox (
   -- ** Parent Property Constructors
   --
   -- $clay-values
-  display, flexDirection, flexWrap, justifyContent, alignItems, aligContent,
+  display, flexDirection, flexWrap, justifyContent, alignItems, alignContent,
 
   -- * Child Properties
   ChildProps (..),
@@ -142,8 +142,8 @@ justifyContent x = mempty { pJustifyContent = pure x }
 alignItems :: AlignItemsValue -> ParentProps
 alignItems x = mempty { pAlignItems = pure x }
 
-aligContent :: AlignContentValue -> ParentProps
-aligContent x = mempty { pAlignContent = pure x }
+alignContent :: AlignContentValue -> ParentProps
+alignContent x = mempty { pAlignContent = pure x }
 
 -- | Properties for a flexbox child.
 data ChildProps = ChildProps {

--- a/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
+++ b/src/Graphics/UI/Threepenny/Ext/Flexbox.hs
@@ -45,9 +45,10 @@ import qualified Graphics.UI.Threepenny      as UI
 import           Graphics.UI.Threepenny.Core hiding (column, row)
 
 -- $clay-values
--- The available values for the Clay argument types can be found in
--- their documentation by drilling down into their instance lists and
--- looking for the methods therein.
+-- The available values for the Clay argument types, if not listed
+-- next to documentation entries for said types, can often be found by
+-- drilling down into their instance lists and looking for the methods
+-- therein.
 
 -- | Bundles of flexbox properties that can be converted to Threepenny
 -- style property-value pairs.
@@ -112,7 +113,9 @@ instance ToStyle ParentProps where
       , CF.alignContent   <$> pAlignContent   p
     ]
 
--- | Default flexbox properties for a parent.
+-- | Default flexbox properties for a parent. Amounts to setting
+-- @display: flex@ plus the CSS specification defaults for the other
+-- flex container properties.
 parentProps :: ParentProps
 parentProps = ParentProps {
     pDisplay        = pure CD.flex
@@ -185,10 +188,11 @@ instance ToStyle ChildProps where
       , CF.alignSelf  <$> cAlignSelf  c
     ]
 
--- | Default flexbox properties for a child.
+-- | Default flexbox properties for a child. Amounts to setting the CSS
+-- defaults for flex item properties.
 childProps :: ChildProps
 childProps = ChildProps {
-    cOrder      = pure 1
+    cOrder      = pure 0
   , cFlexGrow   = pure 0
   , cFlexShrink = pure 1
   , cFlexBasis  = pure CC.auto


### PR DESCRIPTION
These are the couple of changes I mentioned a while ago. Both of them are minor, but breaking. In particular, changing the `order` default to `0` is likely to affect most uses of that property. The upside is that the library defaults will fully match the CSS specification initial values for flex elements.